### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
           awk '/^## \[v?[0-9]+\.[0-9]+\.[0-9]+/{i++} i==1' CHANGELOG.md > LATEST_CHANGELOG.md
 
       - name: Create GitHub Release
+        if: steps.changelog.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- skip GitHub release when latest changelog section is empty

## Testing
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6873c8f60c64833086ba64d11da8a460