### PR TITLE
Update tests for coverage collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
-
-      - name: Start Flask app
-        run: |
-          export FLASK_APP=app.main
-          nohup flask run --host=127.0.0.1 --port=5000 &
-          sleep 5
+          pip install pytest pytest-cov
 
       - name: Run tests with coverage
         run: |

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ python run.py serve
 ## Testing
 
 ```bash
-pytest --cov=app tests/
+pytest --cov=app --cov-report=xml tests/
 ```
 
 ## CI/CD

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 import pytest
 
+from app.main import create_app
+
 
 @pytest.fixture(scope="session")
-def base_url():
-    return "http://127.0.0.1:5000"
+def client():
+    """Flask test client for API routes."""
+    app = create_app()
+    app.testing = True
+    with app.test_client() as client:
+        yield client

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,19 +1,16 @@
-import requests
-
-
-def test_jobs_all(base_url):
-    res = requests.get(f"{base_url}/jobs/all")
+def test_jobs_all(client):
+    res = client.get("/jobs/all")
     assert res.status_code == 200
-    assert isinstance(res.json(), list)
+    assert isinstance(res.get_json(), list)
 
 
-def test_scrape_route(base_url):
+def test_scrape_route(client):
     # Replace this with one of your configured institutions
     company = "M&T Bank"
-    res = requests.post(f"{base_url}/jobs/scrape", json={"companies": [company]})
+    res = client.post("/jobs/scrape", json={"companies": [company]})
     assert res.status_code == 202
 
-    data = res.json()
+    data = res.get_json()
     # If jobs were scraped, we expect a list
     if "scraped" in data:
         assert data["scraped"] is None


### PR DESCRIPTION
## Summary
- run Flask app via its test client in tests
- install pytest-cov in CI and stop starting a live server
- document updated coverage command

## Testing
- `pytest --cov=app --cov-report=xml` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6873d0d977348330a902e2b8d425df67

Closes #4 