### PR TITLE
Add trigger_scrape test

### DIFF
--- a/run.py
+++ b/run.py
@@ -15,9 +15,10 @@ def cli():
 
 @cli.command()
 @click.option(
-    "--companies", "-c",
+    "--companies",
+    "-c",
     multiple=True,
-    help="One or more company names to scrape. If omitted, scrapes all from config."
+    help="One or more company names to scrape. If omitted, scrapes all from config.",
 )
 def scrape(companies):
     """
@@ -33,7 +34,9 @@ def scrape(companies):
 
 @cli.command()
 @click.option("--host", default=config.API_HOST, help="Host to bind the API server to.")
-@click.option("--port", default=config.API_PORT, type=int, help="Port for the API server.")
+@click.option(
+    "--port", default=config.API_PORT, type=int, help="Port for the API server."
+)
 def serve(host, port):
     """
     Launch the Flask API.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -56,3 +56,10 @@ def test_scrape_route(client, monkeypatch, tmp_path):
     rows = res.get_json()
     assert rows
     assert {row["workday_id"] for row in rows} == {"1"}
+
+
+def test_trigger_scrape(client, monkeypatch):
+    monkeypatch.setattr("app.routes.run_scrape", lambda comps: "ok")
+    res = client.post("/jobs/scrape", json={"companies": ["TestCo"]})
+    assert res.status_code == 202
+    assert res.get_json() == {"scraped": "ok"}


### PR DESCRIPTION
## Summary
- add test for /jobs/scrape endpoint using monkeypatch
- format run.py with black

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876bc961f6483309edf1d68be6055e2