### PR TITLE
feat: add Raymond James to institutions and update metadata extraction

### DIFF
--- a/app/scraper_pkg/config/institutions.yaml
+++ b/app/scraper_pkg/config/institutions.yaml
@@ -181,3 +181,7 @@ institutions:
   - name: "Allstate"
     workday_url: "https://allstate.wd5.myworkdayjobs.com/wday/cxs/allstate/allstate_careers/jobs"
     search_text: "sql"
+
+  - name: "Raymond James"
+    workday_url: "https://raymondjames.wd1.myworkdayjobs.com/wday/cxs/raymondjames/RaymondJamesCareers/jobs"
+    search_text: "sql"

--- a/app/scraper_pkg/institution_runner.py
+++ b/app/scraper_pkg/institution_runner.py
@@ -196,6 +196,8 @@ def collect_listing_metadata(cfg):
 
         if company_name == "First Rand" and len(bullet_fields) > 2:
             return bullet_fields[2] or (bullet_fields[0] if bullet_fields else None)
+        elif company_name == "Raymond James" and len(bullet_fields) > 1:
+            return bullet_fields[1] or (bullet_fields[0] if bullet_fields else None)
 
         return bullet_fields[0] if bullet_fields else None
 

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -129,6 +129,41 @@ def test_collect_listing_metadata_first_rand_fallback(monkeypatch):
     }
 
 
+def test_collect_listing_metadata_raymond_james(monkeypatch):
+    posts = [
+        DummyResponse({"facets": []}),
+        DummyResponse(
+            {
+                "jobPostings": [
+                    {
+                        "externalPath": "job/REQRJ",
+                        "bulletFields": ["IGNORE", "REQRJ"],
+                    }
+                ],
+                "total": 1,
+            }
+        ),
+    ]
+
+    def mock_post(url, json=None, headers=None):
+        return posts.pop(0)
+
+    monkeypatch.setattr(runner.requests, "post", mock_post)
+    monkeypatch.setattr(runner.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(config, "SCRAPE_LIMIT", 10)
+
+    inst = {
+        "name": "Raymond James",
+        "workday_url": "http://example.com/jobs",
+        "search_text": "",
+        "locations": [],
+    }
+
+    metadata = collect_listing_metadata(inst)
+
+    assert metadata == {"REQRJ": "http://example.com/job/REQRJ"}
+
+
 def test_fetch_job_details(monkeypatch):
     responses = {
         "http://example.com/job/REQ1": DummyResponse(


### PR DESCRIPTION
## Summary

Updated `app/scraper_pkg/config/institutions.yaml` and  `app/scraper_pkg/institution_runner.py` to handle Raymond James.

## What Changed

- Updated `app/scraper_pkg/config/institutions.yaml` to include Raymond James.
- Added an`elif` block to handle Ramond James where the job_req_id appears in `bulletFields[1]`.

## Why This Was Necessary

- Workday allows `bulletFields` to contain one or more entries in any order with no standardization.
- Some institutions place the job_req_id in a location other than index 0.
-The previous logic handled only `bulletFields[0]` and  `bulletFields[2]`.
- This excluded other positions in the `bulletFields` list.

## How It Works Now

The scraper selects the correct `bulletFields` index (0, 1, or 2) based on the company_name. Requires sufficint length of the bulletFields list. All index options have a fall bback to the 0th index.

## Testing and Verification

- Ran the scrape locally for Raymond James only.
- Verified the scraper completes successfully for Raymond James only.
