### PR TITLE
Add test coverage for Raymond James listing metadata

### DIFF
--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -129,6 +129,41 @@ def test_collect_listing_metadata_first_rand_fallback(monkeypatch):
     }
 
 
+def test_collect_listing_metadata_raymond_james(monkeypatch):
+    posts = [
+        DummyResponse({"facets": []}),
+        DummyResponse(
+            {
+                "jobPostings": [
+                    {
+                        "externalPath": "job/REQRJ",
+                        "bulletFields": ["IGNORE", "REQRJ"],
+                    }
+                ],
+                "total": 1,
+            }
+        ),
+    ]
+
+    def mock_post(url, json=None, headers=None):
+        return posts.pop(0)
+
+    monkeypatch.setattr(runner.requests, "post", mock_post)
+    monkeypatch.setattr(runner.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(config, "SCRAPE_LIMIT", 10)
+
+    inst = {
+        "name": "Raymond James",
+        "workday_url": "http://example.com/jobs",
+        "search_text": "",
+        "locations": [],
+    }
+
+    metadata = collect_listing_metadata(inst)
+
+    assert metadata == {"REQRJ": "http://example.com/job/REQRJ"}
+
+
 def test_fetch_job_details(monkeypatch):
     responses = {
         "http://example.com/job/REQ1": DummyResponse(


### PR DESCRIPTION
## Summary
- add a unit test covering the Raymond James metadata collection path
- verify job requisition IDs are pulled from the second bullet field for Raymond James listings

## Testing
- pytest tests/test_scraper.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691be51e45848330a921b09065e7c085)